### PR TITLE
Refactor bulk user whitelisting to handle duplicates

### DIFF
--- a/backend/app/routes/admin.py
+++ b/backend/app/routes/admin.py
@@ -231,11 +231,13 @@ class BulkWhitelistAPI(Resource):
             users = process_whitelist_csv(csv_content)
 
             # Bulk whitelist the users
-            UserService.bulk_whitelist_users(users)
+            result = UserService.bulk_whitelist_users(users)
 
             return {
-                "message": f"Successfully whitelisted {len(users)} users",
-                "users": users,
+                "message": result["message"],
+                "added": result.get("added", 0),
+                "skipped": result.get("skipped", 0),
+                "total_processed": len(users),
             }, 201
 
         except ValueError as e:


### PR DESCRIPTION


- Updated the bulk_whitelist_users method to skip existing emails and return a summary of added and skipped users.
- Modified the API response to include the number of users added, skipped, and total processed.