### PR TITLE
Update Ten Dice game metadata to adjust session limits and payout values

### DIFF
--- a/backend/app/routes/games/ten_dice/metadata.json
+++ b/backend/app/routes/games/ten_dice/metadata.json
@@ -1,13 +1,13 @@
 {
     "type": "stateless",
     "ignore": false,
-    "default_max_sessions_per_user": 10000,
+    "default_max_sessions_per_user": 800,
     "default_max_bets_per_session": 1,
     "default_is_active": true,
     "default_difficulty": "easy",
     "default_tags": "dice, probability, distribution",
     "default_config": {
         "min_bet_amount": 10,
-        "payout": 20
+        "payout": 15
     }
 }


### PR DESCRIPTION
- Reduced the default maximum sessions per user from 10000 to 800.
- Decreased the payout value in the game configuration from 20 to 15.